### PR TITLE
Fix empty --patch-module command line entries

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -4594,12 +4594,14 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
         }
 
         for (Entry<String, Collection<Path>> entry : patchModules.entrySet()) {
-            addArgIfNotEmpty(
-                    arguments,
-                    "--patch-module",
-                    entry.getKey() + '=' + JavadocUtil.quotedPathArgument(getSourcePath(entry.getValue())),
-                    false,
-                    false);
+            if (!entry.getValue().isEmpty()) {
+                addArgIfNotEmpty(
+                        arguments,
+                        "--patch-module",
+                        entry.getKey() + '=' + JavadocUtil.quotedPathArgument(getSourcePath(entry.getValue())),
+                        false,
+                        false);
+            }
         }
 
         if (doclet != null && !doclet.isEmpty()) {


### PR DESCRIPTION
When using an exclude filter, it is possible that the plugin creates
javadoc --patch-module command line options, that do not actually have
a value.

This changes skips such empty entries.

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
